### PR TITLE
Tf cloudrun service configuration updates

### DIFF
--- a/run/animation/terraform/main.tf
+++ b/run/animation/terraform/main.tf
@@ -82,8 +82,8 @@ resource "google_cloud_run_v2_service" "animator" {
 
       resources {
         limits = {
-          cpu    = "2000m"
-          memory = "2Gi"
+          cpu    = "1000m"
+          memory = "1Gi"
         }
       }
 

--- a/run/animation/terraform/main.tf
+++ b/run/animation/terraform/main.tf
@@ -89,7 +89,7 @@ resource "google_cloud_run_v2_service" "animator" {
 
       startup_probe {
         initial_delay_seconds = 15
-        timeout_seconds       = 15
+        timeout_seconds       = 5
         period_seconds        = 10
         failure_threshold     = 3
         http_get {


### PR DESCRIPTION
* reduce animator resource limits based on usage metrics
* reduce timeout_seconds to 5 seconds, which is now less than the period_seconds of 10