### PR TITLE
Binary auth

### DIFF
--- a/gke/binauthz/README.md
+++ b/gke/binauthz/README.md
@@ -2,6 +2,12 @@
 
 This demo shows how to use Binary Authorization (Binauthz) to enforce security policies on container images deployed in a GKE cluster.
 
+## Prerequisites
+
+- Google Cloud SDK installed and configured
+- A Google Cloud project with billing enabled and a default network
+- kubectl installed and configured
+
 ## Steps
 
 1. **Enable the required APIs**:

--- a/gke/binauthz/README.md
+++ b/gke/binauthz/README.md
@@ -37,7 +37,17 @@ gcloud beta binauthz policy describe
 5. **Create a GKE cluster with Binary Authorization enabled**:
 
 ```bash
-gcloud beta container --project $PROJECT_ID clusters create-auto "demo-cluster" --region $REGION --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
+gcloud beta container clusters create-auto "demo-cluster" \
+  --project $PROJECT_ID \
+  --region $REGION \
+  --release-channel "regular" \
+  --tier "standard" \
+  --enable-ip-access \
+  --no-enable-google-cloud-access \
+  --network "projects/${PROJECT_ID}/global/networks/default" \
+  --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" \
+  --cluster-ipv4-cidr "/17" \
+  --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
 ```
 
 6. **Deploy a sample application**:

--- a/gke/binauthz/README.md
+++ b/gke/binauthz/README.md
@@ -1,43 +1,43 @@
 # Binary Authorization Demo
 
-This demo shows how to use Binary Authorization (Binauthz) to enforce security policies on container images deployed in a GKE cluster. Binauthz is a powerful tool that helps ensure that only trusted images are deployed in your Kubernetes clusters.
+This demo shows how to use Binary Authorization (Binauthz) to enforce security policies on container images deployed in a GKE cluster.
 
 ## Steps
 
 1. **Enable the required APIs**:
 
 ```bash
-   gcloud services enable \
-     container.googleapis.com \
-     binaryauthorization.googleapis.com
+gcloud services enable \
+  container.googleapis.com \
+  binaryauthorization.googleapis.com
 ```
 
 2. **Update placeholders in the policy file**:
 
 ```bash
-    # Set your project ID and region
-    PROJECT_ID=$(gcloud config get-value project)
-    REGION="us-central1"  # Replace with your preferred region
-    sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-policy.yaml
-    sed -i "s/REGION/$REGION/g" binauthz-policy.yaml
+# Set your project ID and region
+PROJECT_ID=$(gcloud config get-value project)
+REGION="us-central1"  # Replace with your preferred region
+sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-policy.yaml
+sed -i "s/REGION/$REGION/g" binauthz-policy.yaml
 ```
 
 3. **Create the Binary Authorization policy**:
 
- ```bash
-    gcloud beta binauthz policy import binauthz-policy.yaml
+```bash
+gcloud beta binauthz policy import binauthz-policy.yaml
  ```
 
 4. **Verify the policy**:
 
 ```bash
-    gcloud beta binauthz policy describe
+gcloud beta binauthz policy describe
 ```
 
 5. **Create a GKE cluster with Binary Authorization enabled**:
 
 ```bash
-    gcloud beta container --project $PROJECT_ID clusters create-auto "demo-cluster" --region $REGION --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
+gcloud beta container --project $PROJECT_ID clusters create-auto "demo-cluster" --region $REGION --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
 ```
 
 6. **Deploy a sample application**:
@@ -47,7 +47,7 @@ Follow the instructions in the [Whereami](https://github.com/gallaglo/whereami) 
 7. **Deploy a non-compliant image**:
 
 ```bash
-    kubectl run busybox --image=docker.io/library/busybox
+kubectl run busybox --image=docker.io/library/busybox
 ```
 
 This should fail due to the Binary Authorization policy.
@@ -55,8 +55,8 @@ This should fail due to the Binary Authorization policy.
 ## Cleanup
 
 ```bash
-    gcloud container clusters delete demo-cluster --region $REGION
-    gcloud beta binauthz policy delete
+gcloud container clusters delete demo-cluster --region $REGION
+gcloud beta binauthz policy delete
 ```
 
 ## Additional Resources

--- a/gke/binauthz/README.md
+++ b/gke/binauthz/README.md
@@ -1,0 +1,65 @@
+# Binary Authorization Demo
+
+This demo shows how to use Binary Authorization (Binauthz) to enforce security policies on container images deployed in a GKE cluster. Binauthz is a powerful tool that helps ensure that only trusted images are deployed in your Kubernetes clusters.
+
+## Steps
+
+1. **Enable the required APIs**:
+
+```bash
+   gcloud services enable \
+     container.googleapis.com \
+     binaryauthorization.googleapis.com
+```
+
+2. **Update placeholders in the policy file**:
+
+```bash
+    # Set your project ID and region
+    PROJECT_ID=$(gcloud config get-value project)
+    REGION="us-central1"  # Replace with your preferred region
+    sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-policy.yaml
+    sed -i "s/REGION/$REGION/g" binauthz-policy.yaml
+```
+
+3. **Create the Binary Authorization policy**:
+
+ ```bash
+    gcloud beta binauthz policy import binauthz-policy.yaml
+ ```
+
+4. **Verify the policy**:
+
+```bash
+    gcloud beta binauthz policy describe
+```
+
+5. **Create a GKE cluster with Binary Authorization enabled**:
+
+```bash
+    gcloud beta container --project $PROJECT_ID clusters create-auto "demo-cluster" --region $REGION --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
+```
+
+6. **Deploy a sample application**:
+
+Follow the instructions in the [Whereami](https://github.com/gallaglo/whereami) repo to deploy the sample application. Ensure that the image used is compliant with the Binary Authorization policy you created.
+
+7. **Deploy a non-compliant image**:
+
+```bash
+    kubectl run busybox --image=docker.io/library/busybox
+```
+
+This should fail due to the Binary Authorization policy.
+
+## Cleanup
+
+```bash
+    gcloud container clusters delete demo-cluster --region $REGION
+    gcloud beta binauthz policy delete
+```
+
+## Additional Resources
+
+- [Binary Authorization Documentation](https://cloud.google.com/binary-authorization/docs)
+- [GKE Documentation](https://cloud.google.com/kubernetes-engine/docs)

--- a/gke/binauthz/README.md
+++ b/gke/binauthz/README.md
@@ -18,29 +18,23 @@ gcloud services enable \
   binaryauthorization.googleapis.com
 ```
 
-2. **Update placeholders in the policy file**:
+1. **Update placeholders in the policy file**:
 
 ```bash
 # Set your project ID and region
 PROJECT_ID=$(gcloud config get-value project)
 REGION="us-central1"  # Replace with your preferred region
-sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-policy.yaml
-sed -i "s/REGION/$REGION/g" binauthz-policy.yaml
+sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-deny-policy.yaml
+sed -i "s/REGION/$REGION/g" binauthz-deny-policy.yaml
 ```
 
-3. **Create the Binary Authorization policy**:
+1. **Create the Binary Authorization policy**:
 
 ```bash
-gcloud beta binauthz policy import binauthz-policy.yaml
+gcloud beta container binauthz policy import binauthz-deny-policy.yaml
  ```
 
-4. **Verify the policy**:
-
-```bash
-gcloud beta binauthz policy describe
-```
-
-5. **Create a GKE cluster with Binary Authorization enabled**:
+1. **Create a GKE cluster with Binary Authorization enabled**:
 
 ```bash
 gcloud beta container clusters create-auto "demo-cluster" \
@@ -51,16 +45,16 @@ gcloud beta container clusters create-auto "demo-cluster" \
   --enable-ip-access \
   --no-enable-google-cloud-access \
   --network "projects/${PROJECT_ID}/global/networks/default" \
-  --subnetwork "projects/${PROJECT_ID}/regions/${PROJECT_ID}/subnetworks/default" \
+  --subnetwork "projects/${PROJECT_ID}/regions/${REGION}/subnetworks/default" \
   --cluster-ipv4-cidr "/17" \
-  --binauthz-evaluation-mode=POLICY_BINDINGS_AND_PROJECT_SINGLETON_POLICY_ENFORCE
+  --binauthz-evaluation-mode=PROJECT_SINGLETON_POLICY_ENFORCE
 ```
 
-6. **Deploy a sample application**:
+1. **Deploy a sample application**:
 
 Follow the instructions in the [Whereami](https://github.com/gallaglo/whereami) repo to deploy the sample application. Ensure that the image used is compliant with the Binary Authorization policy you created.
 
-7. **Deploy a non-compliant image**:
+1. **Deploy a non-compliant image**:
 
 ```bash
 kubectl run busybox --image=docker.io/library/busybox
@@ -72,7 +66,8 @@ This should fail due to the Binary Authorization policy.
 
 ```bash
 gcloud container clusters delete demo-cluster --region $REGION
-gcloud beta binauthz policy delete
+sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" binauthz-allow-policy.yaml
+gcloud beta container binauthz policy import binauthz-allow-policy.yaml
 ```
 
 ## Additional Resources

--- a/gke/binauthz/binauthz-allow-policy.yaml
+++ b/gke/binauthz/binauthz-allow-policy.yaml
@@ -2,4 +2,4 @@ globalPolicyEvaluationMode: ENABLE
 defaultAdmissionRule:
   evaluationMode: ALWAYS_ALLOW
   enforcementMode: ENFORCED_BLOCK_AND_AUDIT_LOG
-name: projects/PROJECT_ID/policy
+name: projects/YOUR_PROJECT_ID/policy

--- a/gke/binauthz/binauthz-allow-policy.yaml
+++ b/gke/binauthz/binauthz-allow-policy.yaml
@@ -1,0 +1,5 @@
+globalPolicyEvaluationMode: ENABLE
+defaultAdmissionRule:
+  evaluationMode: ALWAYS_ALLOW
+  enforcementMode: ENFORCED_BLOCK_AND_AUDIT_LOG
+name: projects/PROJECT_ID/policy

--- a/gke/binauthz/binauthz-deny-policy.yaml
+++ b/gke/binauthz/binauthz-deny-policy.yaml
@@ -5,7 +5,7 @@
 # Whitelist patterns for allowed image repositories
 admissionWhitelistPatterns:
 # This pattern allows all images from your project's Artifact Registry
-- namePattern: gcr.io/YOUR_PROJECT_ID/**
+- namePattern: REGION-docker.pkg.dev/YOUR_PROJECT_ID/**
 
 # Global policy evaluation settings
 globalPolicyEvaluationMode: ENABLE

--- a/gke/binauthz/binauthz-deny-policy.yaml
+++ b/gke/binauthz/binauthz-deny-policy.yaml
@@ -5,7 +5,7 @@
 # Whitelist patterns for allowed image repositories
 admissionWhitelistPatterns:
 # This pattern allows all images from your project's Artifact Registry
-- namePattern: REGION-docker.pkg.dev/YOUR_PROJECT_ID/**
+- namePattern: gcr.io/YOUR_PROJECT_ID/**
 
 # Global policy evaluation settings
 globalPolicyEvaluationMode: ENABLE

--- a/gke/binauthz/binauthz-policy.yaml
+++ b/gke/binauthz/binauthz-policy.yaml
@@ -1,0 +1,19 @@
+# Binary Authorization policy that only allows images from project's Artifact Registry
+# Replace YOUR_PROJECT_ID with your actual Google Cloud project ID
+# Replace REGION with your Artifact Registry region (e.g., us-central1)
+
+# Whitelist patterns for allowed image repositories
+admissionWhitelistPatterns:
+# This pattern allows all images from your project's Artifact Registry
+- namePattern: REGION-docker.pkg.dev/YOUR_PROJECT_ID/**
+
+# Global policy evaluation settings
+globalPolicyEvaluationMode: ENABLE
+
+# Default rule to block all non-whitelisted images
+defaultAdmissionRule:
+  evaluationMode: ALWAYS_DENY
+  enforcementMode: ENFORCED_BLOCK_AND_AUDIT_LOG
+
+# Reference name for this policy
+name: projects/YOUR_PROJECT_ID/policy


### PR DESCRIPTION
Binary Authorization (Binauthz) demo that showcases how to enforce container image security policies in Google Kubernetes Engine clusters.

* Detailed README with step-by-step implementation instructions
* Policy templates for both restrictive (deny) and permissive (allow) configurations
* Complete GKE cluster creation commands with Binauthz enforcement enabled
* Testing procedures for both compliant and non-compliant images
* Proper cleanup instructions to avoid lingering resources

Key security features demonstrated:

* Restricting deployments to images from your project's Artifact Registry only
* Configuring proper admission control and enforcement modes
* Testing the policy with intentional violation examples